### PR TITLE
documentation(EJ2-70836): Namespace name has been changed from `Syncfusion.Blazor.PivotView` to `Syncfusion.EJ2.Pivot`.

### DIFF
--- a/PivotController/PivotController/Controllers/PivotController.cs
+++ b/PivotController/PivotController/Controllers/PivotController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using Newtonsoft.Json;
-using Syncfusion.Blazor.PivotView;
+using Syncfusion.EJ2.PivotView;
 
 namespace PivotController.Controllers
 {

--- a/PivotController/PivotController/Controllers/PivotController.cs
+++ b/PivotController/PivotController/Controllers/PivotController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using Newtonsoft.Json;
-using Syncfusion.EJ2.PivotView;
+using Syncfusion.EJ2.Pivot;
 
 namespace PivotController.Controllers
 {

--- a/PivotController/PivotController/PivotController.csproj
+++ b/PivotController/PivotController/PivotController.csproj
@@ -5,7 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Syncfusion.EJ2.Pivot" Version="21.1.35" />
+    <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
 
 </Project>

--- a/PivotController/PivotController/PivotController.csproj
+++ b/PivotController/PivotController/PivotController.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Syncfusion.EJ2.Pivot" Version="1.0.0" />
+    <PackageReference Include="Syncfusion.EJ2.Pivot" Version="21.1.35" />
   </ItemGroup>
 
 </Project>

--- a/Sample/pivot.html
+++ b/Sample/pivot.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-    <link rel="stylesheet" href="https://cdn.syncfusion.com/ej2/material.css" />
+    <link rel="stylesheet" href="https://cdn.syncfusion.com/ej2/21.1.35/material.css" />
     <script src="https://cdn.syncfusion.com/ej2/dist/ej2.min.js" type="text/javascript"></script>
     <script data-main="pivot" src="require.js"></script>
     <style>


### PR DESCRIPTION
## Pivot Table

### Breaking changes

- In the server side controller, the imported namespace name has been changed from `Syncfusion.Blazor.PivotView` to `Syncfusion.EJ2.Pivot`.